### PR TITLE
feat: reloadWithoutPrompting config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Please make sure the VSCode is totally replaced while upgrading.
 | Key                                         | Description                                                                                                     | Type      | Default    |
 | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
 | `custom-ui-style.preferRestart`             | Prefer to restart vscode after update instead of reload window only (ALWAYS true when VSCode version >= 1.95.0) | `boolean` | `false`    |
+| `custom-ui-style.reloadWithoutPrompting`    | Reload/restart immediately, instead of having to click 'Reload Window' in the notification                      | `boolean` | `false`    |
 | `custom-ui-style.watch`                     | Watch configuration changes and reload window automatically                                                     | `boolean` | `true`     |
 | `custom-ui-style.electron`                  | Electron BrowserWindow options                                                                                  | `object`  | `{}`       |
 | `custom-ui-style.font.monospace`            | Global monospace font family that apply in both editor and webview, fallback to editor's font family            | `string`  | ``         |

--- a/package.json
+++ b/package.json
@@ -59,6 +59,12 @@
           "description": "Prefer to restart vscode after update instead of reload window only (ALWAYS true when VSCode version >= 1.95.0)",
           "default": false
         },
+        "custom-ui-style.reloadWithoutPrompting": {
+          "scope": "resource",
+          "type": "boolean",
+          "description": "Reload/restart immediately, instead of having to click 'Reload Window' in the notification",
+          "default": false
+        },
         "custom-ui-style.watch": {
           "scope": "resource",
           "type": "boolean",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,8 +59,14 @@ export async function runAndRestart(message: string, fullRestart: boolean, actio
       success = false
     }
     if (success) {
-      const item = await showMessage(message, 'Reload Window', 'Cancel')
-      if (item === 'Reload Window') {
+      let shouldProceed = false
+      if (config.reloadWithoutPrompting) {
+        shouldProceed = true
+      } else {
+        const item = await showMessage(message, 'Reload Window', 'Cancel')
+        shouldProceed = item === 'Reload Window'
+      }
+      if (shouldProceed) {
         if (fullRestart) {
           try {
             await restartApp()


### PR DESCRIPTION
Add a config `custom-ui-style.reloadWithoutPrompting` to remove one manual step from the edit→reload→observe dev cycle