### PR TITLE
ci: setup github action for release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    tags:
+      - "*"
+
+name: Deploy Extension
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install -g pnpm
+      - run: pnpm install
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com


### PR DESCRIPTION
# What
- Implement CI for releasing the extension to Visual Studio Code and OpenVSE Marketplace.

# How
- Refer to the following link for guidance: https://github.com/HaaLeo/publish-vscode-extension

# Why
- This will enable support for Visual Studio Code-forked extensions, such as VSCodium.

P/S: Not working yet on this repo but you could refer to my extension here https://github.com/jellydn/vscode-hurl-runner/blob/main/.github/workflows/publish.yml

In the meantime, I've just published your extension to https://open-vsx.org/extension/subframe7536/custom-ui-style You could claim to your when you've created an account.