### PR TITLE
Fix Windows restart script to handle VSC Insiders

### DIFF
--- a/src/restart.ts
+++ b/src/restart.ts
@@ -87,7 +87,7 @@ async function restartWindows() {
     '    Start-Sleep -Milliseconds 100',
     '}',
   ].join('')
-  const batchScript = `taskkill /F /IM ${exeName}.exe >nul && powershell -Command "${checkScript}" && "${binary}"`
+  const batchScript = `taskkill /F /IM "${exeName}.exe" >nul && powershell -Command "${checkScript}" && "${binary}"`
 
   return spawn(
     process.env.comspec ?? 'cmd',


### PR DESCRIPTION
On Windows (I'm not sure how other platforms handle this, might be worth checking) the Insiders executable is `Code - Insiders.exe` with spaces (thanks microsoft), so the current restart batch script fails and it has to be restarted manually. Changing `${exeName}.exe` to `"${exeName}.exe"` handles this so it succeeds even with spaces in the name.