### PR TITLE
fix(linux): restart VS Code by PID after custom UI reload

### DIFF
--- a/src/restart.ts
+++ b/src/restart.ts
@@ -7,6 +7,13 @@ import { readFileSync } from 'atomically'
 
 import { baseDir, productJSONPath } from './path'
 
+export class ManualRestartRequiredError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ManualRestartRequiredError'
+  }
+}
+
 export async function restartApp(): Promise<void> {
   let sp
   switch (process.platform) {
@@ -117,16 +124,20 @@ async function restartWindows() {
 async function restartLinux() {
   const appHomeDir = path.dirname(process.execPath)
   const binary = getAppBinary(`${appHomeDir}/bin/`)
-  const processName = path.basename(process.execPath)
+  const vscodePID = Number(process.env.VSCODE_PID)
+
+  if (!Number.isInteger(vscodePID) || vscodePID <= 0) {
+    throw new ManualRestartRequiredError('Cannot determine the VS Code main process on Linux. Please fully quit and reopen VS Code to apply changes.')
+  }
 
   return spawn(
     '/bin/sh',
     [
       '-c',
       `
-      pkill -f "${processName}"
+      kill "${vscodePID}" 2>/dev/null || exit 1
       counter=0
-      while pgrep -f "${processName}" > /dev/null && [ $counter -lt 100 ]; do
+      while kill -0 "${vscodePID}" 2>/dev/null && [ $counter -lt 100 ]; do
         sleep 0.1
         counter=$((counter + 1))
       done

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ import { config } from './config'
 import * as Meta from './generated/meta'
 import { log } from './logger'
 import { baseDir } from './path'
-import { restartApp } from './restart'
+import { ManualRestartRequiredError, restartApp } from './restart'
 
 export const fileProtocol = 'file://'
 export const httpsProtocol = 'https://'
@@ -34,6 +34,11 @@ function logWindowOptionsChanged(useFullRestart: boolean) {
     showMessage(`Note: Please TOTALLY restart VSCode (${method}) to take effect, "custom-ui-style.electron" is changed`)
   }
   last = current
+}
+
+async function notifyManualRestartRequired(error: ManualRestartRequiredError) {
+  log.warn(error.message)
+  await showMessage(error.message)
 }
 
 export async function runAndRestart(message: string, fullRestart: boolean, action: () => Promise<any>, instantRestart = false) {
@@ -84,7 +89,15 @@ export async function runAndRestart(message: string, fullRestart: boolean, actio
 
   if (success) {
     if (instantRestart) {
-      await restartApp()
+      try {
+        await restartApp()
+      } catch (error) {
+        if (error instanceof ManualRestartRequiredError) {
+          await notifyManualRestartRequired(error)
+        } else {
+          throw error
+        }
+      }
       return
     }
     let shouldProceed = false
@@ -103,7 +116,11 @@ export async function runAndRestart(message: string, fullRestart: boolean, actio
         try {
           await restartApp()
         } catch (error) {
-          logError('Fail to restart VSCode', error)
+          if (error instanceof ManualRestartRequiredError) {
+            await notifyManualRestartRequired(error)
+          } else {
+            logError('Fail to restart VSCode', error)
+          }
         }
       } else {
         commands.executeCommand('workbench.action.reloadWindow')


### PR DESCRIPTION
## Summary

Fix a Linux-specific restart issue that occurs after applying Custom UI Style updates.

The extension was successfully patching VS Code files, but the automatic restart path on Linux could hang, crash, or require a force close. After reopening VS Code manually, the custom style was applied correctly, which showed that the patching step itself was working and the failure was in the restart logic.

## Root cause

The Linux restart flow was using process-name matching:

- `pkill -f "<processName>"`
- `pgrep -f "<processName>"`

This is too broad for VS Code on Linux. `pkill -f` and `pgrep -f` match full command lines, not a single exact process, so the restart flow could kill or wait on the wrong processes. That made the shutdown/relaunch sequence unreliable and caused the editor to hang during restart even though the modified files had already been written successfully.

## Fix

Replace the Linux restart implementation with a PID-targeted flow.

The restart script now:

1. Resolves the VS Code main process PID from `VSCODE_PID`
2. Kills that exact PID
3. Waits for that exact PID to exit
4. Relaunches VS Code

This makes the restart deterministic and avoids broad process matching across unrelated or child processes.

## Why PID is safer than process name

A process name identifies a group of possible matches. A PID identifies one exact process.

For this restart path, PID-based shutdown is the correct approach because it:

- targets the current VS Code main process only
- avoids matching helper or child processes
- avoids false positives from full command-line matching
- prevents restart races caused by broad `pkill`/`pgrep` behavior

## Fallback behavior

If the extension cannot determine the VS Code main process on Linux, it now treats that as a manual-restart case and shows a plain notification instructing the user to fully quit and reopen VS Code.

This is surfaced as expected user guidance instead of a generic restart failure.

## Result

- Linux reload still applies the patched UI files correctly
- automatic restart no longer relies on unsafe process-name matching
- the hang/crash path during restart is avoided
- users get a clear manual-restart notification when automatic restart cannot be performed safely


### Disclamer

This PR was drafted with help from GPT-5.4, using GitHub Copilot.