### PR TITLE
Handle `EACCES: permission denied` for Antigravity on Arch

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,7 +77,10 @@ export async function runAndRestart(
           err,
         )
         return
-      } else if (err.message.includes('Maximum call stack size exceeded')) {
+      } else if (
+        err.message.includes('Maximum call stack size exceeded') ||
+        ('code' in err && err.code === 'EACCES')
+      ) {
         logError(
           `${base} current user is not allowed. Please run "sudo chown -R $(whoami) '${path.dirname(baseDir)}'" to grant permissions`,
           err,


### PR DESCRIPTION
First of all, thanks for your extension, it's really helpful!

Recently I installed Antigravity IDE on Arch Linux and got `[ERROR] Unknown error in npm:atomically, Error: EACCES: permission denied, open '/opt/antigravity-ide/resources/app/out/__custom-ui-style__.lock.tmp-4417901372e0c738'` when tried to apply my styles.

I looked through the code and found the `sudo chown -R $(whoami) ...` idea that helped me. So I think adding `EACCES` check _(code check is enough to match the error in my case)_ there could also help others